### PR TITLE
Added support for optional "relative" parameter to `darken` and `lighten`

### DIFF
--- a/src/com/inet/lib/less/FunctionExpression.java
+++ b/src/com/inet/lib/less/FunctionExpression.java
@@ -564,12 +564,20 @@ class FunctionExpression extends Expression {
                     return;
                 case "lighten":
                     hsl = toHSL( getColor( 0, formatter ) );
-                    hsl.l += getPercent( 1, formatter );
+                    if (parameters.size() > 2 && "relative".equals( get( 2 ).stringValue( formatter )) ) {
+                        hsl.l += hsl.l * getPercent(1, formatter);
+                    } else {
+                        hsl.l += getPercent(1, formatter);
+                    }
                     doubleValue = hsla( hsl );
                     return;
                 case "darken":
                     hsl = toHSL( getColor( 0, formatter ) );
-                    hsl.l -= getPercent( 1, formatter );
+                    if (parameters.size() > 2 && "relative".equals( get( 2 ).stringValue( formatter )) ) {
+                        hsl.l -= hsl.l * getPercent(1, formatter);
+                    } else {
+                        hsl.l -= getPercent(1, formatter);
+                    }
                     doubleValue = hsla( hsl );
                     return;
                 case "fadein":

--- a/test/com/inet/lib/less/samples/less_org_tests/less/functions.css
+++ b/test/com/inet/lib/less/samples/less_org_tests/less/functions.css
@@ -9,7 +9,9 @@
 #built-in {
   escaped: -Some::weird(#thing, y);
   lighten: #ffcccc;
+  lighten-relative: #ff6666;
   darken: #330000;
+  darken-relative: #990000;
   saturate: #203c31;
   desaturate: #29332f;
   greyscale: #2e2e2e;

--- a/test/com/inet/lib/less/samples/less_org_tests/less/functions.less
+++ b/test/com/inet/lib/less/samples/less_org_tests/less/functions.less
@@ -13,7 +13,9 @@
   @r: 32;
   escaped: e("-Some::weird(#thing, y)");
   lighten: lighten(#ff0000, 40%);
+  lighten-relative: lighten(#ff0000, 40%, relative);
   darken: darken(#ff0000, 40%);
+  darken-relative: darken(#ff0000, 40%, relative);
   saturate: saturate(#29332f, 20%);
   desaturate: desaturate(#203c31, 20%);
   greyscale: greyscale(#203c31);


### PR DESCRIPTION
Implemented in the same way as it's done in the reference implementation