### PR TITLE
Fix rule inlining mechanism with nested rules.

### DIFF
--- a/src/com/inet/lib/less/Rule.java
+++ b/src/com/inet/lib/less/Rule.java
@@ -577,7 +577,7 @@ class Rule extends LessObject implements Formattable, FormattableContainer {
         }
 
         for( Rule rule : subrules ) {
-            if( rule.isValidCSS( formatter ) && rule.isInlineRule( formatter) ) {
+            if( rule.isValidCSS( formatter ) && !rule.isInlineRule( formatter) ) {
                 return false;
             }
         }

--- a/test/com/inet/lib/less/samples/general/parent-selectors.css
+++ b/test/com/inet/lib/less/samples/general/parent-selectors.css
@@ -1,0 +1,3 @@
+.foo .bar {
+  color: blue;
+}

--- a/test/com/inet/lib/less/samples/general/parent-selectors.less
+++ b/test/com/inet/lib/less/samples/general/parent-selectors.less
@@ -1,0 +1,7 @@
+.foo {
+  & {
+    .bar {
+      color: blue;
+    }
+  }
+}


### PR DESCRIPTION
Should fix #58 

Looks like `!` operator is missing when checking subrules to decide if the current rule should be inlined.

New unit test added.
All `gradle check` tests still pass.